### PR TITLE
[Fix] fix Dockerfile to copy jar file with right name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ LABEL authors="Xenα"
 ADD ./build/libs/libertygame-achievement-0.1.0-SNAPSHOT.jar /app.jar
 EXPOSE 8080
 
-CMD ["java", "-jar", "/app.jar"]
+CMD ["java", "-jar", "/app.jar", "-Dfile.encoding=UTF-8", "-Dconsole.encoding=UTF-8"]


### PR DESCRIPTION
포함할 jar 파일 이름 정정
+
charset 옵션과 함께 시작하도록 수정